### PR TITLE
Allow use of private model hub models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![fastt5 icon](https://raw.githubusercontent.com/Ki6an/fastT5/master/data/fastT5.png)
 
 
-<h2 style="text-align:center; font-weight: bold">Reduce T5 model size by 3X and increase the inference speed up to 5X. 
+<h2 style="text-align:center; font-weight: bold">Reduce T5 model size by 3X and increase the inference speed up to 5X.
 </h2>
 
 <p align="center">
@@ -20,7 +20,7 @@
  </p>
 
 </br>
- 
+
 
 - [Install](#install)
 - [Usage](#usage)
@@ -36,13 +36,13 @@
 - [Acknowledgements](#acknowledgements)
 
 
-T5 models can be used for several NLP tasks such as summarization, QA, QG, translation, text generation, and more. Sequential text generation is naturally slow,  and for larger T5 models it gets even slower. **fastT5** makes the T5 models inference faster by running it on onnxruntime. and it also decreases the model size by quantizing it. 
+T5 models can be used for several NLP tasks such as summarization, QA, QG, translation, text generation, and more. Sequential text generation is naturally slow,  and for larger T5 models it gets even slower. **fastT5** makes the T5 models inference faster by running it on onnxruntime. and it also decreases the model size by quantizing it.
 
 fastT5 library allows you to convert a pretrained T5 model to onnx, quantizes it, and gives the model as output which is running on an onnxruntime in a single line of code. You can also customize this whole process.
 
 
 ---
-## Install 
+## Install
 You can install fastT5 from PyPI:
 ```python
  pip install fastt5
@@ -55,7 +55,7 @@ pip3 install -e .
 ```
 
 
-## Usage 
+## Usage
 
 The `export_and_get_onnx_model()` method exports the given pretrained T5 model to onnx, quantizes it and runs it on the onnxruntime with default settings. The returned model from this method supports the `generate()` method of huggingface.
 
@@ -79,7 +79,7 @@ tokens = model.generate(input_ids=token['input_ids'],
 output = tokenizer.decode(tokens.squeeze(), skip_special_tokens=True)
 print(output)
 ```
-> to run the already exported model use `get_onnx_model()` 
+> to run the already exported model use `get_onnx_model()`
 
 you can customize the whole pipeline as shown in the below code example:
 
@@ -105,16 +105,16 @@ model = OnnxT5(model_or_model_path, model_sessions)
                       ...
 ```
 
-## Details 
-T5 is a `seq2seq` model (Encoder-Decoder), as it uses decoder repeatedly for inference, we can't directly export the whole model to onnx. We need to export the encoder and decoder separately. 
+## Details
+T5 is a `seq2seq` model (Encoder-Decoder), as it uses decoder repeatedly for inference, we can't directly export the whole model to onnx. We need to export the encoder and decoder separately.
 
 > `past_key_values` contain pre-computed hidden-states (key and values in the self-attention blocks and cross-attention blocks) that can be used to speed up sequential decoding.
 
 models can only be exported with a constant number of inputs. Contrary to this, the decoder of the first step does not take `past_key_values` and the rest of the steps decoders do. To get around this issue,  we can create two decoders: one for the first step that does not take `past_key_values` and another for the rest of the steps that utilize the `past_key_values`.
 
-Next, we'll export all three models (encoder, decoder, init_decoder). And then quantize them, quantizing `32bit` to `8bit` should give the 4x memory reduction. Since there is an extra decoder the model size reduces by 3x. 
+Next, we'll export all three models (encoder, decoder, init_decoder). And then quantize them, quantizing `32bit` to `8bit` should give the 4x memory reduction. Since there is an extra decoder the model size reduces by 3x.
 
-Finally, we'll run the quantized model on onnx runtime. 
+Finally, we'll run the quantized model on onnx runtime.
 
 >The inference is simple as the model supports the [`generate()`](https://huggingface.co/transformers/main_classes/model.html?highlight=generate#transformers.generation_utils.GenerationMixin.generate) method of huggingface.
 
@@ -146,7 +146,7 @@ Quantized models are lightweight models as mentioned earlier, these models have 
 
 
 ![t5-base-quant](https://raw.githubusercontent.com/Ki6an/fastT5/master/data/t5-base-quant.png)
- 
+
 The model outperforms the PyTorch model by 5.7X for greedy search on average and 3-4X for beam search.
 
 
@@ -155,7 +155,7 @@ The model outperforms the PyTorch model by 5.7X for greedy search on average and
 
 > Note : The results were generated on `AMD EPYC 7B12`, these results may vary from device to device. The Onnx models usually perform well on high-end CPUs with more cores.
 
-## Quantized model scores 
+## Quantized model scores
 The results were tested for English to French translation with beam search number of 3.
 
 |                    | Bleu_4   | METEOR   | ROUGE_L  |
@@ -168,7 +168,43 @@ The results were tested for English to French translation with beam search numbe
 | t5-large (pytorch) | 0.294015 | 0.315774 | 0.508677 |
 
 
-## further improvements 
+## Private HugginFace Model Hub Models
+
+The [HUggingFace model hub](https://huggingface.co/models) supports private models. To use a private, pre-trained version of T5 with fastT5 you first must have authenticated into HuggingFace ecosystem with `$ transformers-cli login`. Then, when using fastT5, there is an extra import and call:
+
+```python
+from fastT5 import (
+    OnnxT5,
+    get_onnx_runtime_sessions,
+    generate_onnx_representation,
+    quantize,
+    set_auth_token)
+from transformers import AutoTokenizer
+
+set_auth_token(True)
+# the rest of the code is the same as using a public model
+```
+
+If you are unable to call `$ transformers-cli login` or prefer to use your API Key, found at https://huggingface.co/settings/token (or https://huggingface.co/organizations/ORG_NAME/settings/token for organizations), you can pass that as a string to `set_auth_token`. Avoid hard-coding your API key into code by setting the environment variable `HF_API_KEY=<redacted>`, and then in code:
+
+```python
+import os
+
+from fastT5 import (
+    OnnxT5,
+    get_onnx_runtime_sessions,
+    generate_onnx_representation,
+    quantize,
+    set_auth_token)
+from transformers import AutoTokenizer
+
+auth_token = os.environ.get("HF_API_KEY")
+set_auth_token(auth_token)
+
+# code proceeds as normal
+```
+
+## further improvements
 - currently the fastT5 library supports only the cpu version of onnxruntime, gpu implementation still needs to be done.
 - graph optimization of the onnx model will further reduce the latency.
 

--- a/fastT5/__init__.py
+++ b/fastT5/__init__.py
@@ -1,3 +1,4 @@
+from .huggingface_utils import set_auth_token
 from .onnx_models import OnnxT5, export_and_get_onnx_model, get_onnx_model
 from .ort_settings import get_onnx_runtime_sessions
 from .onnx_exporter import generate_onnx_representation, quantize

--- a/fastT5/huggingface_utils.py
+++ b/fastT5/huggingface_utils.py
@@ -1,0 +1,25 @@
+_auth_token = None
+
+def set_auth_token(token):
+    """Set the token which allows the user to authenticate to hugginface.co for downloading private models
+
+    Args:
+        token (Union[str, bool]): The token value to store. One of:
+            - an API key (from https://huggingface.co/organizations/ORGNAME/settings/token),
+            - a login token obtained by running `$ transformers-cli login`
+            - `True`, which tells transformers to use the login token stored in ~/.huggingface/token
+
+    Returns:
+        None
+    """
+    global _auth_token
+    _auth_token = token
+
+def get_auth_token():
+    """Get the user-configurable auth token, which defaults to None
+
+    Returns:
+        auth_token (Optional[Union[str, bool]]) for authenticating with huggingface.co
+    """
+    global _auth_token
+    return _auth_token

--- a/fastT5/onnx_exporter.py
+++ b/fastT5/onnx_exporter.py
@@ -1,3 +1,4 @@
+from .huggingface_utils import get_auth_token
 from .onnx_models_structure import (
     T5Encoder,
     DecoderWithLMhead,
@@ -34,7 +35,7 @@ def create_t5_encoder_decoder(pretrained_version="t5-base"):
         decoder_with_lm_head: pytorch t5 decoder with a language modeling head
     """
 
-    model = T5ForConditionalGeneration.from_pretrained(pretrained_version)
+    model = T5ForConditionalGeneration.from_pretrained(pretrained_version, use_auth_token=get_auth_token())
 
     return turn_model_into_encoder_decoder(model)
 
@@ -83,7 +84,7 @@ def generate_onnx_representation(pretrained_version=None, model=None, output_pat
         pretrained_version, output_path, quantized=False
     )
 
-    model_config = AutoConfig.from_pretrained(pretrained_version)
+    model_config = AutoConfig.from_pretrained(pretrained_version, use_auth_token=get_auth_token())
 
     # dummy inputs
     batch_size = 5

--- a/fastT5/onnx_models.py
+++ b/fastT5/onnx_models.py
@@ -1,3 +1,4 @@
+from .huggingface_utils import get_auth_token
 from .ort_settings import get_onnx_runtime_sessions
 from .onnx_exporter import (
     generate_onnx_representation,
@@ -116,7 +117,7 @@ class OnnxT5(T5ForConditionalGeneration):
     """ creates a T5 model using onnx sessions (encode, decoder & init_decoder) """
 
     def __init__(self, model_or_model_path, onnx_model_sessions):
-        config = T5Config.from_pretrained(model_or_model_path)
+        config = T5Config.from_pretrained(model_or_model_path, use_auth_token=get_auth_token())
         super().__init__(config)
 
         assert len(onnx_model_sessions) == 3, "all three models should be given"


### PR DESCRIPTION
Calls to the `from_pretrained` method have a parameter, `use_auth_token` which defaults to `None`. Setting this to a string passes a token or API key to HF, and setting it to `True` instructs `transformers` to look in `~/.huggingface/token` for an authentication token.

This PR explicitly sets that argument to None by default, but adds a new method, `fastT5.set_auth_token`, which allows users to pass an auth token, API key, or `True` if credentials are stored locally.

It adds documentation as well.