### PR TITLE
add `psutil` to deps in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
         "transformers==4.6.1",
         "progress>=1.5",
         "sentencepiece",
+        "psutil",
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
`psutil` is currently missing in `setup.py`, leading to a `ModuleNotFoundError` in a fresh environment. This PR fixes that