### PR TITLE
small onnx optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ set_auth_token(auth_token)
 - [original T5 paper](https://arxiv.org/pdf/1910.10683.pdf)
 - [transformers](https://github.com/huggingface/transformers) by huggingface
 - [onnx](https://github.com/onnx/onnx)
-- [onnxruntime ](https://github.com/microsoft/onnxruntime) by microsoft
+- [onnxruntime](https://github.com/microsoft/onnxruntime) by microsoft
 - [onnxt5](https://github.com/abelriboulot/onnxt5)
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         "torch>=1.7.0,!=1.8.0",  # excludes torch v1.8.0
         "onnx",
         "onnxruntime==1.7.0",
-        "transformers>=4.12.5",
+        "transformers>4.6.1",
         "progress>=1.5",
         "sentencepiece",
         "psutil",


### PR DESCRIPTION
A few small tweaks:

* Set transformers version to `>4.6.1` — this is the minimum necessary requirement
* make sequence length configurable, so ORT can use this information when optimizing. Also set batch_size to 1, since this is all CPU inference, ORT should optimize for batch size 1
* use U8S8 per [ONNX docs](https://onnxruntime.ai/docs/performance/quantization.html#data-type-selection) and add reduce_range to help with saturation issue
* make opset version configurable for users who want to experiment with more recent ONNX versions