### PR TITLE
Explicit mt5 support

### DIFF
--- a/fastT5/onnx_exporter.py
+++ b/fastT5/onnx_exporter.py
@@ -5,11 +5,9 @@ from .onnx_models_structure import (
     DecoderWithLMheadInitial,
 )
 from transformers import (
-    T5Tokenizer,
-    AutoTokenizer,
     AutoConfig,
-    AutoModelForSeq2SeqLM,
     T5ForConditionalGeneration,
+    MT5ForConditionalGeneration,
 )
 import torch
 import functools
@@ -35,7 +33,10 @@ def create_t5_encoder_decoder(pretrained_version="t5-base"):
         decoder_with_lm_head: pytorch t5 decoder with a language modeling head
     """
 
-    model = T5ForConditionalGeneration.from_pretrained(pretrained_version, use_auth_token=get_auth_token())
+    if 'mt5' in pretrained_version:
+        model = MT5ForConditionalGeneration.from_pretrained(pretrained_version, use_auth_token=get_auth_token())
+    else:
+        model = T5ForConditionalGeneration.from_pretrained(pretrained_version, use_auth_token=get_auth_token())
 
     return turn_model_into_encoder_decoder(model)
 

--- a/fastT5/onnx_models_structure.py
+++ b/fastT5/onnx_models_structure.py
@@ -1,11 +1,4 @@
 import torch
-from transformers import (
-    T5Tokenizer,
-    AutoTokenizer,
-    AutoConfig,
-    AutoModelForSeq2SeqLM,
-    T5ForConditionalGeneration,
-)
 
 
 class DecoderWithLMhead(torch.nn.Module):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="fastt5",
-    version="0.0.8",
+    version="0.1.0",
     license="apache-2.0",
     author="Kiran R",
     author_email="kiranr8k@gmail.com",


### PR DESCRIPTION
We closed #20 but there is a possibility of errors when using `T5ForConditionalGeneration` with an `mt5` model; this adds more explicit support for mt5 models.

It also removes some unused imports and bumps the version