### PR TITLE
Cuda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ tokenizer = AutoTokenizer.from_pretrained(model_name)
 t_input = "translate English to French: The universe is a dark forest."
 token = tokenizer(t_input, return_tensors='pt')
 
+# only necessary when using cuda               
+model = model.to('cuda')
+token = token.to('cuda')
+
 tokens = model.generate(input_ids=token['input_ids'],
                attention_mask=token['attention_mask'],
                num_beams=2)

--- a/fastT5/onnx_models.py
+++ b/fastT5/onnx_models.py
@@ -199,7 +199,10 @@ class OnnxT5(T5ForConditionalGeneration):
 
 
 def export_and_get_onnx_model(
-    model_or_model_path, custom_output_path=saved_models_path, quantized=True
+    model_or_model_path,
+    custom_output_path=saved_models_path,
+    quantized=True,
+    input_sequence_length=256
 ):
     """
                           Method for whole pipeline,
@@ -210,7 +213,9 @@ def export_and_get_onnx_model(
 
     # Step 1. convert huggingfaces t5 model to onnx
     onnx_model_paths = generate_onnx_representation(
-        model_or_model_path, output_path=custom_output_path
+        model_or_model_path,
+        output_path=custom_output_path,
+        input_sequence_length=input_sequence_length
     )
 
     if quantized:

--- a/fastT5/ort_settings.py
+++ b/fastT5/ort_settings.py
@@ -19,6 +19,7 @@ def get_onnx_runtime_sessions(
     parallel_exe_mode: bool = True,
     n_threads: int = 0,
     provider=[
+        'CUDAExecutionProvider',
         "CPUExecutionProvider",
     ],
 ) -> InferenceSession:
@@ -49,11 +50,11 @@ def get_onnx_runtime_sessions(
 
     if default:
 
-        encoder_sess = InferenceSession(str(path_to_encoder))
+        encoder_sess = InferenceSession(str(path_to_encoder), providers=provider)
 
-        decoder_sess = InferenceSession(str(path_to_decoder))
+        decoder_sess = InferenceSession(str(path_to_decoder), providers=provider)
 
-        decoder_sess_init = InferenceSession(str(path_to_initial_decoder))
+        decoder_sess_init = InferenceSession(str(path_to_initial_decoder), providers=provider)
 
     else:
 

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.5",
     install_requires=[
-        "torch>=1.7.0,!=1.8.0",  # excludes torch v1.8.0
+        "torch>=1.7.0",
         "onnx",
-        "onnxruntime==1.7.0",
+        "onnxruntime-gpu>=1.7.0",
         "transformers>4.6.1",
         "progress>=1.5",
         "sentencepiece",


### PR DESCRIPTION
I've added support for CUDA by using ORT `io_bindings`. This allows for even faster inference and is capable of both CPU and CUDA inference. The only downside is, that quantized models are slow on cuda. Therefore quantization should be disabled when exporting the model to onnx and using cuda. 